### PR TITLE
Update whitelist.yaml add amazonaws

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -32,6 +32,8 @@
   - url: revoke.cash
   - url: *.walletconnect.com
   - url: *.walletconnect.org
+  - url: "*.amazonaws.com"
+
   - url: *.web3modal.com
   - url: *.web3modal.org
   - url: *.web3inbox.com


### PR DESCRIPTION
Whitelist *.amazonaws.com to support NFT collections hosted on AWS